### PR TITLE
Add OCI Compute shape naming convention to Compute Hardware page

### DIFF
--- a/cloud-infrastructure/compute-including-hpc/compute-hardware/README.md
+++ b/cloud-infrastructure/compute-including-hpc/compute-hardware/README.md
@@ -9,11 +9,12 @@ This page has information about Oracle Cloud Infrastructure (OCI) Compute hardwa
 ## Useful Links
 
 - [Arm Based Compute](https://docs.oracle.com/en-us/iaas/Content/Compute/References/arm.htm)
-- [Confidential Compute](https://confluence.oraclecorp.com/confluence/display/EMEACSS/Confidential+Compute?src=contextnavpagetreemode)
+- [Confidential Computing](https://docs.oracle.com/en-us/iaas/Content/Compute/References/confidential_compute.htm) - data and the application processing the data are encrypted 
 - [Oracle Blog - Oracle Cloud Infrastructure Bare Metal Shapes and Specifications](https://blogs.oracle.com/cloud-infrastructure/post/oracle-cloud-infrastructure-bare-metal-shapes-and-specifications)
 - [Dedicated VM Hosts](https://docs.oracle.com/en-us/iaas/Content/Compute/Concepts/dedicatedvmhosts.htm)
 - [Changing the shape of a compute instance: X5 to X9, or VM.Standard2 series to Flexible instance](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/resizinginstances.htm#Changing_the_Shape_of_an_Instance)
 - [Deploy high-performance computing (HPC) on Oracle Cloud Infrastructure](https://docs.oracle.com/en/solutions/deploy-hpc-on-oci/index.html#GUID-F216B94E-33C5-44A6-92F8-2DE1E5880242)
+- [OCI Compute shape naming convention (https://github.com/mariusscholtz/Oracle-Cloud-Infrastructure-resources) ex A refers to Ampere, E refers to AMD Epyc
 
 # License
 

--- a/cloud-infrastructure/compute-including-hpc/compute-hardware/README.md
+++ b/cloud-infrastructure/compute-including-hpc/compute-hardware/README.md
@@ -14,7 +14,7 @@ This page has information about Oracle Cloud Infrastructure (OCI) Compute hardwa
 - [Dedicated VM Hosts](https://docs.oracle.com/en-us/iaas/Content/Compute/Concepts/dedicatedvmhosts.htm)
 - [Changing the shape of a compute instance: X5 to X9, or VM.Standard2 series to Flexible instance](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/resizinginstances.htm#Changing_the_Shape_of_an_Instance)
 - [Deploy high-performance computing (HPC) on Oracle Cloud Infrastructure](https://docs.oracle.com/en/solutions/deploy-hpc-on-oci/index.html#GUID-F216B94E-33C5-44A6-92F8-2DE1E5880242)
-- [OCI Compute shape naming convention] (https://github.com/mariusscholtz/Oracle-Cloud-Infrastructure-resources) ex A refers to Ampere, E refers to AMD Epyc
+- [OCI Compute shape naming convention](https://github.com/mariusscholtz/Oracle-Cloud-Infrastructure-resources) ex VM Shape name with A refers to Ampere, E refers to AMD Epyc
 
 # License
 

--- a/cloud-infrastructure/compute-including-hpc/compute-hardware/README.md
+++ b/cloud-infrastructure/compute-including-hpc/compute-hardware/README.md
@@ -14,7 +14,7 @@ This page has information about Oracle Cloud Infrastructure (OCI) Compute hardwa
 - [Dedicated VM Hosts](https://docs.oracle.com/en-us/iaas/Content/Compute/Concepts/dedicatedvmhosts.htm)
 - [Changing the shape of a compute instance: X5 to X9, or VM.Standard2 series to Flexible instance](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/resizinginstances.htm#Changing_the_Shape_of_an_Instance)
 - [Deploy high-performance computing (HPC) on Oracle Cloud Infrastructure](https://docs.oracle.com/en/solutions/deploy-hpc-on-oci/index.html#GUID-F216B94E-33C5-44A6-92F8-2DE1E5880242)
-- [OCI Compute shape naming convention (https://github.com/mariusscholtz/Oracle-Cloud-Infrastructure-resources) ex A refers to Ampere, E refers to AMD Epyc
+- [OCI Compute shape naming convention] (https://github.com/mariusscholtz/Oracle-Cloud-Infrastructure-resources) ex A refers to Ampere, E refers to AMD Epyc
 
 # License
 


### PR DESCRIPTION
Also replaced Confidential Compute link that was pointing to Confluence page and changed to public page