### PR TITLE
Fixed timing delay before using bastion session resource.

### DIFF
--- a/security/security-design/shared-assets/bastion-session-script/files/bastion-session.sh
+++ b/security/security-design/shared-assets/bastion-session-script/files/bastion-session.sh
@@ -11,7 +11,7 @@
 ###############################################################################
 
 # Set default values.
-version="1.0.2"
+version="1.0.3"
 oci_profile="DEFAULT"
 session_name="Bastion-Session"
 session_check_counter=15  # times 10 seconds for maximum time while checking session creation status.
@@ -153,7 +153,7 @@ oci_create_bastion_session() {
    cmd="oci bastion session get --session-id ${session_id} ${oci_options}"
    until [ $session_check_counter == 0 ]
    do
-      sleep 10
+      sleep 5
       if ! run_oci_cmd; then
          echo "*** Problem retrieving OCI Bastion session status: ${session_id}"
          exit 1
@@ -165,6 +165,7 @@ oci_create_bastion_session() {
       else
          session_check_counter=0
       fi
+      sleep 5
    done
    if [ "${session_status}" != "ACTIVE" ]; then
       echo "*** Problem creating OCI Bastion session. Failed on status: ${session_status}"

--- a/security/security-design/shared-assets/bastion-session-script/release-notes.md
+++ b/security/security-design/shared-assets/bastion-session-script/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Feb 20, 2024 Release Notes - v1.0.3
+
+- Fixed an issue where sometimes the bastion session resource was used before it was fully ready.
+
 ## Jul 4, 2023 Release Notes - v1.0.2
 
 - Documentation and textual improvements.


### PR DESCRIPTION
Fix for small issue where OCI reports the session is ready, but it just takes a little longer to be ready.