### PR TITLE
Update README.md - Add page to transfer to and from cloud

### DIFF
--- a/cloud-infrastructure/compute-including-hpc/compute-software/README.md
+++ b/cloud-infrastructure/compute-including-hpc/compute-software/README.md
@@ -2,7 +2,7 @@
 
 This page contains information and useful links regarding Compute services that are mostly related to OS and Licenses Management on top of OCI Compute. You can also find resources about BYOI, BYOH and Autoscaling.
 
-<i>Review date: 04 March 2024</i>
+<i>Review date: 24 May 2024</i>
 
 # Table of Contents
 
@@ -26,7 +26,8 @@ This page contains information and useful links regarding Compute services that 
 - [Cluster software on Oracle Linux 9 using Corosync and Pacemaker - create failover IP](https://github.com/mariusscholtz/Oracle-Cloud-Infrastructure-resources/blob/main/cluster/readme.md)
 - [Script to install and mount OCI bucket as Filesystem using Fuse S3FS](https://github.com/Olygo/OCI_S3FS)
 - [Mount a boot volume from one compute instance (or VM) onto another compute instance in order to replace lost ssh keys](https://gitlab.com/ms76152/system-administration)
-
+- [Transfer data to and from Oracle Cloud Infrastructure using OS tools such as sftp, scp, oci cli, curl](https://github.com/mariusscholtz/Oracle-Cloud-Infrastructure-resources/blob/main/VM-shapes/data%20transfer%20to%20OCI%20v1.0.pdf)
+  
 # Useful Links
 
 - [Managing Custom Images](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/managingcustomimages.htm)


### PR DESCRIPTION
Create a new document: Transfer data to and from Oracle Cloud Infrastructure using OS tools such as sftp, scp, oci cli, curl. This document explains how to use these technologies and where to find more resources