### PR TITLE
2 OCPU/8 GB runner shape

### DIFF
--- a/app-dev/devops-and-containers/devops/oci-devops-terraform-function-java-graalvm/files/devops.tf
+++ b/app-dev/devops-and-containers/devops/oci-devops-terraform-function-java-graalvm/files/devops.tf
@@ -402,8 +402,8 @@ resource oci_devops_build_pipeline_stage export_build {
   build_pipeline_stage_type = "BUILD"
   build_runner_shape_config {
     build_runner_type = "CUSTOM"
-    memory_in_gbs     = "512"
-    ocpus             = "8"
+    memory_in_gbs     = "8"
+    ocpus             = "2"
   }
   build_source_collection {
     items {


### PR DESCRIPTION
Let's use the smallest custom shape for native build 2 ocpu / 8 GB, I tested a lot and a larger shape did not give any extra boost here 