### PR TITLE
Sync oci-enterprise-ai-chat to v0.5.0

### DIFF
--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/package.json
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "oci-agent-light-demo-creator",
-  "version": "0.4.0",
+  "name": "oci-enterprise-ai-chat",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/api/mcp/oauth/authorize/route.js
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/api/mcp/oauth/authorize/route.js
@@ -27,20 +27,46 @@ export async function GET(request) {
       return NextResponse.json({ error: 'endpoint query param is required' }, { status: 400 });
     }
 
+    // Static-client mode (authType `oauth2-user`): the caller supplies the
+    // pre-registered OAuth credentials in the query string. We skip discovery
+    // and dynamic client registration entirely and just run PKCE.
+    const staticClientId = params.get('clientId');
+    const staticClientSecret = params.get('clientSecret') || '';
+    const staticAuthorizeUrl = params.get('authorizeUrl');
+    const staticTokenUrl = params.get('tokenUrl');
+    const staticScope = params.get('scope') || '';
+    const useStatic = !!(staticClientId && staticAuthorizeUrl && staticTokenUrl);
+
     const baseUrl = getBaseUrl(request);
     const redirectUri = `${baseUrl}/api/mcp/oauth/callback`;
 
-    // 1. Discover OAuth metadata from MCP server
-    const metadata = await fetchOAuthMetadata(endpoint);
-    if (!metadata) {
-      return NextResponse.json({ error: 'MCP server does not support OAuth 2.1' }, { status: 502 });
-    }
-    log.info('OAuth metadata fetched', { endpoint });
+    let clientId, clientSecret, authorizationEndpoint, tokenEndpoint, scopeList;
 
-    // 2. Register this app as an OAuth client (dynamic registration)
-    const scopes = metadata.scopes_supported || ['read', 'write', 'generate'];
-    const registration = await registerClient(metadata.registration_endpoint, redirectUri, scopes);
-    log.info('Client registered', { clientId: registration.client_id });
+    if (useStatic) {
+      clientId = staticClientId;
+      clientSecret = staticClientSecret;
+      authorizationEndpoint = staticAuthorizeUrl;
+      tokenEndpoint = staticTokenUrl;
+      scopeList = staticScope.split(/\s+/).filter(Boolean);
+      log.info('OAuth (static client) authorize', { endpoint, authorizationEndpoint });
+    } else {
+      // 1. Discover OAuth metadata from MCP server (oauth2.1 flow)
+      const metadata = await fetchOAuthMetadata(endpoint);
+      if (!metadata) {
+        return NextResponse.json({ error: 'MCP server does not support OAuth 2.1' }, { status: 502 });
+      }
+      log.info('OAuth metadata fetched', { endpoint });
+
+      // 2. Register this app as an OAuth client (dynamic registration)
+      scopeList = metadata.scopes_supported || ['read', 'write', 'generate'];
+      const registration = await registerClient(metadata.registration_endpoint, redirectUri, scopeList);
+      log.info('Client registered', { clientId: registration.client_id });
+
+      clientId = registration.client_id;
+      clientSecret = registration.client_secret;
+      authorizationEndpoint = metadata.authorization_endpoint;
+      tokenEndpoint = metadata.token_endpoint;
+    }
 
     // 3. Generate PKCE pair
     const codeVerifier = generateCodeVerifier();
@@ -50,25 +76,31 @@ export async function GET(request) {
     // 4. Store pending state in a signed cookie
     const pending = await signPayload({
       endpoint,
-      clientId: registration.client_id,
-      clientSecret: registration.client_secret,
+      clientId,
+      clientSecret,
       codeVerifier,
       state,
-      tokenEndpoint: metadata.token_endpoint,
+      tokenEndpoint,
       redirectUri,
       returnTo,
     });
 
     // 5. First set the cookie, then redirect via an HTML page
     //    (direct 307 redirect may not persist cookies in all browsers)
-    const authUrl = new URL(metadata.authorization_endpoint);
-    authUrl.searchParams.set('client_id', registration.client_id);
+    const authUrl = new URL(authorizationEndpoint);
+    authUrl.searchParams.set('client_id', clientId);
     authUrl.searchParams.set('redirect_uri', redirectUri);
     authUrl.searchParams.set('response_type', 'code');
-    authUrl.searchParams.set('scope', scopes.join(' '));
+    if (scopeList.length > 0) authUrl.searchParams.set('scope', scopeList.join(' '));
     authUrl.searchParams.set('code_challenge', codeChallenge);
     authUrl.searchParams.set('code_challenge_method', 'S256');
     authUrl.searchParams.set('state', state);
+    // Google requires these to issue a refresh_token + force the consent prompt
+    // the first time. Harmless for other providers (they'll just ignore unknown params).
+    if (useStatic) {
+      authUrl.searchParams.set('access_type', 'offline');
+      authUrl.searchParams.set('prompt', 'consent');
+    }
 
     const html = `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=${authUrl.toString()}"></head><body>Redirecting...</body></html>`;
     const response = new Response(html, {

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/api/mcp/route.js
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/api/mcp/route.js
@@ -75,8 +75,9 @@ export async function POST(request) {
     // Add auth headers if provided
     let updatedTokenCookie = null; // set if oauth2.1 token was refreshed
 
-    if (authType === 'oauth2.1') {
-      // Read tokens from httpOnly cookie set by /api/mcp/oauth/callback
+    if (authType === 'oauth2.1' || authType === 'oauth2-user') {
+      // Read tokens from httpOnly cookie set by /api/mcp/oauth/callback.
+      // Both interactive authTypes share the same callback + cookie storage.
       const cookieName = tokenCookieName(endpoint);
       const tokenCookie = request.cookies.get(cookieName)?.value;
       const tokens = await verifyPayload(tokenCookie);
@@ -144,8 +145,8 @@ export async function POST(request) {
     if (!response.ok) {
       log.error('MCP server error', { status: response.status, body: responseText.slice(0, 500) });
 
-      // If the MCP server rejects our OAuth 2.1 token, clear it and ask for re-auth
-      if (authType === 'oauth2.1' && response.status === 401) {
+      // If the MCP server rejects our OAuth token, clear it and ask for re-auth
+      if ((authType === 'oauth2.1' || authType === 'oauth2-user') && response.status === 401) {
         const clearResponse = NextResponse.json({
           error: 'needs_auth',
           authorizeUrl: `/api/mcp/oauth/authorize?endpoint=${encodeURIComponent(endpoint)}`,

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/api/responses/route.js
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/api/responses/route.js
@@ -551,11 +551,53 @@ export async function POST(request) {
                   else if (itemType === 'image_generation_call') {
                     controller.enqueue(encoder.encode(JSON.stringify({ generated_image: data.item.result || '' }) + '\n'));
                   }
-                  // Function call completed
+                  // Function call completed.
+                  //
+                  // Two distinct flavors:
+                  // (a) mcp__<server>__<tool> name → the model wants an MCP tool
+                  //     run but OCI did NOT execute it itself (typical with
+                  //     gpt-oss-120b). The output field is empty. We must run
+                  //     the tool on the client side and submit a
+                  //     function_call_output back via a chained Responses call.
+                  // (b) anything else → legacy client-side function_call path.
                   else if (itemType === 'function_call') {
-                    controller.enqueue(encoder.encode(JSON.stringify({
-                      function_call: { id: itemId, callId: data.item.call_id, name: data.item.name, arguments: data.item.arguments }
-                    }) + '\n'));
+                    const fname = data.item.name || '';
+                    const mcpMatch = fname.match(/^mcp__([^_]+(?:_[^_]+)*?)__(.+)$/);
+                    if (mcpMatch) {
+                      const [, serverLabel, toolName] = mcpMatch;
+                      // Find the pending mcp_call entry (added at output_item.added);
+                      // its id is what the UI chip uses.
+                      const tc = toolCalls.find(t =>
+                        t.tool === toolName && t.server === serverLabel && !t.outputSent
+                      );
+                      const chipItemId = tc?.id || itemId;
+                      // Signal to the client that this is an MCP tool the client
+                      // must execute itself (gpt-oss-120b et al). Includes the
+                      // call_id + arguments needed to do the round-trip.
+                      controller.enqueue(encoder.encode(JSON.stringify({
+                        mcp_function_call: {
+                          item_id: chipItemId,
+                          call_id: data.item.call_id,
+                          fn_name: fname,
+                          server_label: serverLabel,
+                          tool_name: toolName,
+                          arguments: data.item.arguments || '{}',
+                        }
+                      }) + '\n'));
+                      // Mark the toolCall entry as "delegated" so the soft-close
+                      // detector doesn't classify it as a hard error.
+                      if (tc) {
+                        tc.outputSent = true;
+                        tc.delegated = true;
+                      }
+                      traceEvent('mcp_call_delegated', { tool: toolName, server: serverLabel, call_id: data.item.call_id });
+                      log.info('MCP tool delegated to client-side executor', { tool: toolName, server: serverLabel, callId: data.item.call_id });
+                    } else {
+                      // Real client-side function call (legacy path)
+                      controller.enqueue(encoder.encode(JSON.stringify({
+                        function_call: { id: itemId, callId: data.item.call_id, name: data.item.name, arguments: data.item.arguments }
+                      }) + '\n'));
+                    }
                   }
                   // Reasoning item done — signal end-of-reasoning to the UI
                   else if (itemType === 'reasoning') {
@@ -984,24 +1026,17 @@ export async function POST(request) {
             } catch (_) { /* controller may already be closing */ }
           }
 
-          // Detect premature close: OCI dropped connection without response.completed
+          // Stream ended. If OCI didn't explicitly send response.completed we just
+          // treat the close as a normal end — the UI shows whatever state the
+          // chips reached. No fabricated error, no soft/hard classification.
+          // Network-level failures still bubble through the outer try/catch.
           if (!responseCompleted && !stalled) {
-            log.error('PREMATURE STREAM CLOSE — OCI never sent response.completed', {
-              elapsed, eventCount, lastEventType, toolCalls, textLength: fullOutputText.length, opcRequestId,
-              buffer: buffer.substring(0, 500),
+            log.info('Stream ended without response.completed (treated as normal end)', {
+              elapsed, eventCount, lastEventType, toolCalls: toolCalls.map(t => t.tool), opcRequestId,
             });
             trace.opcRequestId = opcRequestId;
-            trace.error = `OCI closed connection after ${Math.round(elapsed / 1000)}s without response.completed. ` +
-              `Received ${eventCount} events, last was "${lastEventType || 'none'}". ` +
-              `${toolCalls.length > 0 ? `Active tools: ${toolCalls.map(t => t.tool).join(', ')}. ` : ''}` +
-              `This is an OCI Responses API issue — the upstream closed the SSE stream prematurely.`;
-            traceEvent('premature_close', { eventCount, lastEventType });
             try {
-              controller.enqueue(encoder.encode(JSON.stringify({
-                error: trace.error,
-                done: true,
-                trace,
-              }) + '\n'));
+              controller.enqueue(encoder.encode(JSON.stringify({ done: true, trace }) + '\n'));
             } catch (_) { /* controller may already be closing */ }
           }
 

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/components/chat/ChatInput.js
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/components/chat/ChatInput.js
@@ -54,7 +54,6 @@ const DrawioLogoSmall = ({ size = 14, color = "#F08705" }) => (
 
 const ADDON_TOOLS_META = {
   addon_drawio: { name: "OCI Draw.io", color: "#F08705", LogoComponent: DrawioLogoSmall },
-  addon_sdd: { name: "OCI SDD Generator", color: "#0EA5E9", icon: FileText },
   addon_ppt: { name: "OCI PPT Generator", color: "#EF4444", icon: Presentation },
 };
 

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/components/chat/ChatMessage.js
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/components/chat/ChatMessage.js
@@ -22,6 +22,7 @@ import { Check, Copy, ChevronDown as ChevronDownIcon, Code, FileText, X, Brain, 
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import JsonView from "@uiw/react-json-view";
+import { MCPService } from "../../services/mcpService";
 
 import Sources from "../agent/Sources";
 import DotMatrixLoader from "../ui/DotMatrixLoader";
@@ -1389,10 +1390,10 @@ const ChatMessage = memo(function ChatMessage({
               let buttonLabel;
               let onClickAction;
               const returnTo = typeof window !== 'undefined' ? window.location.pathname + window.location.search : '/';
-              const openOAuth = () => { window.location.href = `/api/mcp/oauth/authorize?endpoint=${encodeURIComponent(server.endpoint)}&returnTo=${encodeURIComponent(returnTo)}`; };
+              const openOAuth = () => { window.location.href = MCPService.buildAuthorizeUrl(server, returnTo); };
               const openSettings = () => { window.location.href = server ? `/settings/tools?focus=${encodeURIComponent(server.id)}` : '/settings/tools'; };
 
-              if (authType === 'oauth2.1') {
+              if (authType === 'oauth2.1' || authType === 'oauth2-user') {
                 title = `Authorization needed — ${displayName}`;
                 description = `Sign in to "${displayName}" to grant access. After authorizing you'll return here.`;
                 buttonLabel = 'Authorize';

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/components/settings/ToolForm.js
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/components/settings/ToolForm.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReducer } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useReducer } from "react";
 import {
   Box,
   TextField,
@@ -19,6 +19,7 @@ import {
   FormControlLabel,
 } from "@mui/material";
 import { Plug, Eye, EyeOff, X, Check, Wand2, Wrench, ShieldAlert } from "lucide-react";
+import { Icon } from "@iconify/react";
 import mcpService from "../../services/mcpService";
 
 function makeInitial(initial) {
@@ -28,6 +29,7 @@ function makeInitial(initial) {
     authType: initial?.authType || "none",
     authKey: initial?.authKey || "",
     oauthTokenUrl: initial?.oauth?.tokenUrl || "",
+    oauthAuthorizeUrl: initial?.oauth?.authorizeUrl || "",
     oauthClientId: initial?.oauth?.clientId || "",
     oauthClientSecret: initial?.oauth?.clientSecret || "",
     oauthScope: initial?.oauth?.scope || "",
@@ -45,6 +47,36 @@ function makeInitial(initial) {
       || (Array.isArray(initial?.requireApprovalTools) && initial.requireApprovalTools.length > 0),
   };
 }
+
+// Presets: one-click filler for popular OAuth providers that don't support dynamic
+// client registration. User still has to paste their own clientId/clientSecret from
+// the provider's developer console, but URLs and scopes are auto-populated.
+const OAUTH_USER_PRESETS = [
+  {
+    id: 'google-gmail',
+    label: 'Google Gmail',
+    icon: 'logos:google-icon',
+    authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+    tokenUrl:     'https://oauth2.googleapis.com/token',
+    scope:        'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose',
+  },
+  {
+    id: 'github',
+    label: 'GitHub',
+    icon: 'logos:github-icon',
+    authorizeUrl: 'https://github.com/login/oauth/authorize',
+    tokenUrl:     'https://github.com/login/oauth/access_token',
+    scope:        'repo read:user',
+  },
+  {
+    id: 'slack',
+    label: 'Slack',
+    icon: 'logos:slack-icon',
+    authorizeUrl: 'https://slack.com/oauth/v2/authorize',
+    tokenUrl:     'https://slack.com/api/oauth.v2.access',
+    scope:        'channels:read chat:write',
+  },
+];
 
 function reducer(state, action) {
   switch (action.type) {
@@ -65,7 +97,7 @@ function formatTestError(err) {
   if (/MCP request failed:\s*403/i.test(raw)) return "Forbidden (403). Credentials valid but lack permission.";
   if (/MCP request failed:\s*404/i.test(raw)) return "Endpoint not found (404). Check the URL.";
   if (/MCP request failed:\s*5\d\d/i.test(raw)) return `Server error: ${raw.replace(/MCP request failed:\s*/i, "")}`;
-  if (/Failed to fetch|NetworkError|ERR_NETWORK/i.test(raw)) return "Network error — endpoint unreachable, CORS blocked, or DNS issue.";
+  if (/Failed to fetch|NetworkError|ERR_NETWORK/i.test(raw)) return "Network error: endpoint unreachable, CORS blocked, or DNS issue.";
   if (/needs_auth/i.test(raw)) return "OAuth flow required. Use authType OAuth 2.1 (interactive) for this endpoint.";
   return raw.length > 240 ? raw.slice(0, 240) + "…" : raw;
 }
@@ -79,7 +111,7 @@ function formatTestError(err) {
  *   - onSave: (serverData, testTools) => void   — receives the data to persist
  *   - onCancel: () => void
  */
-export default function ToolForm({ mode = "add", initialValues = null, onSave, onCancel }) {
+function ToolFormInner({ mode = "add", initialValues = null, onSave, onCancel, onStateChange }, ref) {
   const isEdit = mode === "edit";
   const [s, d] = useReducer(reducer, initialValues, makeInitial);
 
@@ -111,6 +143,17 @@ export default function ToolForm({ mode = "add", initialValues = null, onSave, o
         clientSecret: s.oauthClientSecret.trim(),
         scope: s.oauthScope.trim() || undefined,
       };
+    } else if (s.authType === "oauth2-user") {
+      // OAuth 2.0 authorization_code + PKCE with a pre-registered client.
+      // Used for providers (Google, GitHub, Slack…) that do not implement
+      // RFC 7591 dynamic client registration.
+      server.oauth = {
+        authorizeUrl: s.oauthAuthorizeUrl.trim(),
+        tokenUrl:     s.oauthTokenUrl.trim(),
+        clientId:     s.oauthClientId.trim(),
+        clientSecret: s.oauthClientSecret.trim(),
+        scope:        s.oauthScope.trim() || undefined,
+      };
     }
     // oauth2.1 is handled by the OAuth flow (no creds in form)
     server.requireApproval = !!s.requireApproval;
@@ -126,6 +169,10 @@ export default function ToolForm({ mode = "add", initialValues = null, onSave, o
     }
     if (s.authType === "oauth2") {
       if (!s.oauthTokenUrl.trim() || !s.oauthClientId.trim()) return false;
+      if (!s.oauthClientSecret.trim() && !(isEdit && initialValues?.oauth?.clientSecret)) return false;
+    }
+    if (s.authType === "oauth2-user") {
+      if (!s.oauthAuthorizeUrl.trim() || !s.oauthTokenUrl.trim() || !s.oauthClientId.trim()) return false;
       if (!s.oauthClientSecret.trim() && !(isEdit && initialValues?.oauth?.clientSecret)) return false;
     }
     return true;
@@ -154,6 +201,26 @@ export default function ToolForm({ mode = "add", initialValues = null, onSave, o
     }
     onSave(buildServer(), tools || []);
   };
+
+  // Expose imperative handles so a parent (e.g. a Dialog rendering its own
+  // DialogActions footer) can trigger save/test without owning the buttons.
+  useImperativeHandle(ref, () => ({
+    save: handleSave,
+    test: handleTest,
+  }), [handleSave, handleTest]);
+
+  // Notify the parent about state changes that should drive button
+  // enabled/loading states. Only emits primitive snapshots, no handlers,
+  // so the dependency list stays simple and there is no risk of loops.
+  useEffect(() => {
+    onStateChange?.({
+      isValid,
+      isLoading: s.testLoading,
+      authType: s.authType,
+      testStatus: s.testStatus,
+      testToolsCount: s.testTools?.length || 0,
+    });
+  }, [isValid, s.testLoading, s.authType, s.testStatus, s.testTools, onStateChange]);
 
   // Auto-discovery: try /.well-known/oauth-authorization-server on the endpoint origin
   const handleDetect = async () => {
@@ -185,13 +252,13 @@ export default function ToolForm({ mode = "add", initialValues = null, onSave, o
           patch: {
             authType: "oauth2.1",
             oauthTokenUrl: meta.token_endpoint || s.oauthTokenUrl,
-            detectMsg: "OAuth 2.1 metadata detected — switched auth type to OAuth 2.1 (interactive). Click Add to register, then Authorize from the chat.",
+            detectMsg: "OAuth 2.1 metadata detected, switched auth type to OAuth 2.1 (interactive). Click Add to register, then Authorize from the chat.",
             detecting: false,
           },
         });
         return;
       }
-      d({ type: "patch", patch: { detecting: false, detectMsg: "No OAuth metadata at this URL — keep current auth type." } });
+      d({ type: "patch", patch: { detecting: false, detectMsg: "No OAuth metadata at this URL. Keep current auth type." } });
     } catch (e) {
       d({ type: "patch", patch: { detecting: false, detectMsg: `Detect failed: ${e.message || e}` } });
     }
@@ -208,12 +275,6 @@ export default function ToolForm({ mode = "add", initialValues = null, onSave, o
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      {mode === "add" && (
-        <Typography variant="subtitle2" sx={{ fontWeight: 500 }}>
-          Add MCP Tool
-        </Typography>
-      )}
-
       {mode === "add" && (
         <TextField
           label="Tool Name"
@@ -271,14 +332,15 @@ export default function ToolForm({ mode = "add", initialValues = null, onSave, o
       )}
 
       <Box sx={{ display: "flex", gap: 2, alignItems: "flex-start" }}>
-        <FormControl size="small" sx={{ minWidth: 220 }}>
+        <FormControl size="small" sx={{ minWidth: 320 }}>
           <InputLabel>Authentication</InputLabel>
           <Select value={s.authType} label="Authentication" onChange={setAuthType}>
-            <MuiMenuItem value="none">None</MuiMenuItem>
-            <MuiMenuItem value="api-key">API Key (X-API-KEY)</MuiMenuItem>
-            <MuiMenuItem value="bearer">Bearer Token</MuiMenuItem>
-            <MuiMenuItem value="oauth2">OAuth 2.0 (Client Credentials)</MuiMenuItem>
-            <MuiMenuItem value="oauth2.1">OAuth 2.1 (Interactive / PKCE)</MuiMenuItem>
+            <MuiMenuItem value="none">None: public MCP server</MuiMenuItem>
+            <MuiMenuItem value="api-key">API Key: static header</MuiMenuItem>
+            <MuiMenuItem value="bearer">Bearer Token: static token</MuiMenuItem>
+            <MuiMenuItem value="oauth2">OAuth 2.0: Service (Client Credentials)</MuiMenuItem>
+            <MuiMenuItem value="oauth2.1">OAuth 2.1: User Sign-in (Auto-discovery)</MuiMenuItem>
+            <MuiMenuItem value="oauth2-user">OAuth 2.0: User Sign-in (Manual setup)</MuiMenuItem>
           </Select>
         </FormControl>
 
@@ -295,6 +357,16 @@ export default function ToolForm({ mode = "add", initialValues = null, onSave, o
           />
         )}
       </Box>
+
+      {/* Inline guidance: which authType for what scenario */}
+      <Typography sx={{ fontSize: "0.72rem", color: "var(--dm-muted, rgba(0,0,0,0.55))", mt: -1, ml: 0.5, lineHeight: 1.55 }}>
+        {s.authType === "none" && "No credentials required. The MCP server is publicly reachable."}
+        {s.authType === "api-key" && "The MCP server validates a fixed API key sent on every request as X-API-KEY."}
+        {s.authType === "bearer" && "The MCP server validates a fixed bearer token sent as Authorization: Bearer <token>."}
+        {s.authType === "oauth2" && "Server-to-server. No user login. You provide a client_id + client_secret, we fetch a short-lived token from the token URL on every request. Use for back-office connectors (e.g. IDCS, OIC) where the principal is the application itself."}
+        {s.authType === "oauth2.1" && "User sign-in, fully automatic. The MCP server publishes /.well-known/oauth-authorization-server and supports RFC 7591 dynamic client registration. You only paste the endpoint, we register and run the PKCE flow."}
+        {s.authType === "oauth2-user" && "User sign-in, manual setup. For providers that do NOT support dynamic registration (Google, GitHub, Slack, Microsoft). You pre-create an OAuth client in the provider's developer console, paste client_id + client_secret + the authorize/token URLs here, and we run the PKCE flow against them."}
+      </Typography>
 
       {s.authType === "oauth2" && (
         <Box
@@ -355,9 +427,110 @@ export default function ToolForm({ mode = "add", initialValues = null, onSave, o
             lineHeight: 1.5,
           }}
         >
-          OAuth 2.1 is interactive. After saving, click <strong>Authorize</strong> from the chat banner the first time
-          a tool from this server is invoked. PKCE + dynamic client registration is performed automatically using the
-          server&apos;s discovery metadata.
+          After saving, click <strong>Authorize</strong> from the chat to sign in. PKCE and client registration are handled automatically.
+        </Box>
+      )}
+
+      {s.authType === "oauth2-user" && (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+            borderLeft: "3px solid var(--dm-border, rgba(0,0,0,0.08))",
+            paddingLeft: 2,
+          }}
+        >
+          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", alignItems: "center" }}>
+            <Typography sx={{ fontSize: "0.75rem", color: "var(--dm-muted, rgba(0,0,0,0.55))", mr: 0.5 }}>
+              Preset:
+            </Typography>
+            {OAUTH_USER_PRESETS.map(p => (
+              <Chip
+                key={p.id}
+                icon={<Icon icon={p.icon} width={14} height={14} />}
+                label={p.label}
+                size="small"
+                onClick={() => d({
+                  type: "patch",
+                  patch: {
+                    oauthAuthorizeUrl: p.authorizeUrl,
+                    oauthTokenUrl: p.tokenUrl,
+                    oauthScope: p.scope,
+                  },
+                })}
+                sx={{ fontSize: "0.72rem", cursor: "pointer", "& .MuiChip-icon": { ml: "8px", mr: "-4px" } }}
+              />
+            ))}
+          </Box>
+          <TextField
+            label="Authorize URL"
+            value={s.oauthAuthorizeUrl}
+            onChange={set("oauthAuthorizeUrl")}
+            placeholder="https://accounts.google.com/o/oauth2/v2/auth"
+            size="small"
+            fullWidth
+          />
+          <TextField
+            label="Token URL"
+            value={s.oauthTokenUrl}
+            onChange={set("oauthTokenUrl")}
+            placeholder="https://oauth2.googleapis.com/token"
+            size="small"
+            fullWidth
+          />
+          <Box sx={{ display: "flex", gap: 2 }}>
+            <TextField
+              label="Client ID"
+              value={s.oauthClientId}
+              onChange={set("oauthClientId")}
+              placeholder="From provider's developer console"
+              size="small"
+              fullWidth
+            />
+            <TextField
+              label="Client Secret"
+              value={s.oauthClientSecret}
+              onChange={set("oauthClientSecret")}
+              size="small"
+              fullWidth
+              type={s.showSecret ? "text" : "password"}
+              slotProps={{ input: { endAdornment: showSecretAdornment } }}
+            />
+          </Box>
+          <TextField
+            label="Scopes (space-separated)"
+            value={s.oauthScope}
+            onChange={set("oauthScope")}
+            placeholder="e.g. https://www.googleapis.com/auth/gmail.readonly"
+            size="small"
+            fullWidth
+          />
+          <Box sx={{
+            p: 1.5,
+            borderRadius: 1,
+            backgroundColor: "rgba(14, 165, 233, 0.06)",
+            border: "1px solid rgba(14, 165, 233, 0.2)",
+            fontSize: "0.78rem",
+            color: "rgba(0,0,0,0.7)",
+            lineHeight: 1.5,
+          }}>
+            Set your OAuth redirect URI in the provider's console to:{" "}
+            <Box
+              component="span"
+              sx={{
+                fontWeight: 600,
+                fontFamily: "inherit",
+                px: 0.5,
+                py: 0.25,
+                borderRadius: 0.5,
+                backgroundColor: "var(--dm-subtle, rgba(0,0,0,0.06))",
+              }}
+            >
+              {typeof window !== "undefined" ? `${window.location.origin}/api/mcp/oauth/callback` : "<your-origin>/api/mcp/oauth/callback"}
+            </Box>
+            <br />After saving, click <strong>Authorize</strong> from the chat banner to sign in the first time.
+          </Box>
         </Box>
       )}
 
@@ -376,42 +549,6 @@ export default function ToolForm({ mode = "add", initialValues = null, onSave, o
           {s.testError}
         </Box>
       )}
-
-      <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end", alignItems: "center" }}>
-        {s.testStatus === "connected" && (
-          <Chip
-            icon={<Plug size={14} />}
-            label={s.testTools ? `Connected · ${s.testTools.length} tools` : "Connected"}
-            size="small"
-            color="success"
-            variant="outlined"
-            sx={{ mr: 1 }}
-          />
-        )}
-        <Button variant="outlined" size="small" onClick={onCancel} startIcon={<X size={14} />}>
-          Cancel
-        </Button>
-        {s.authType !== "oauth2.1" && (
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={handleTest}
-            disabled={!isValid || s.testLoading}
-            startIcon={s.testLoading ? <CircularProgress size={14} /> : <Plug size={14} />}
-          >
-            Test Connection
-          </Button>
-        )}
-        <Button
-          variant="contained"
-          size="small"
-          onClick={handleSave}
-          disabled={!isValid || s.testLoading}
-          startIcon={s.testLoading ? <CircularProgress size={14} /> : <Check size={14} />}
-        >
-          {isEdit ? "Save" : "Add Tool"}
-        </Button>
-      </Box>
 
       {/* Server-level human approval. OCI Responses API only supports per-server
           granularity for require_approval, so this is a single switch. */}
@@ -432,7 +569,7 @@ export default function ToolForm({ mode = "add", initialValues = null, onSave, o
             Require user approval
           </Typography>
           <Typography sx={{ fontSize: "0.72rem", color: "var(--dm-muted, rgba(0,0,0,0.55))", lineHeight: 1.4 }}>
-            Ask the user to confirm before any tool from this server runs. Applies to all tools — OCI does not support per-tool granularity.
+            Ask the user to confirm before any tool from this server runs. Applies to all tools. OCI does not support per-tool granularity.
           </Typography>
         </Box>
         <Switch
@@ -484,7 +621,18 @@ export default function ToolForm({ mode = "add", initialValues = null, onSave, o
                     <Typography sx={{ fontWeight: 500, fontSize: "0.85rem" }}>{tool.name}</Typography>
                     {tool.description && (
                       <Typography
-                        sx={{ fontSize: "0.75rem", color: "var(--dm-muted, rgba(0,0,0,0.5))", lineHeight: 1.5, mt: 0.25 }}
+                        title={tool.description}
+                        sx={{
+                          fontSize: "0.75rem",
+                          color: "var(--dm-muted, rgba(0,0,0,0.5))",
+                          lineHeight: 1.5,
+                          mt: 0.25,
+                          display: "-webkit-box",
+                          WebkitLineClamp: 2,
+                          WebkitBoxOrient: "vertical",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                        }}
                       >
                         {tool.description}
                       </Typography>
@@ -496,6 +644,10 @@ export default function ToolForm({ mode = "add", initialValues = null, onSave, o
           </Box>
         );
       })()}
+
     </Box>
   );
 }
+
+const ToolForm = forwardRef(ToolFormInner);
+export default ToolForm;

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/components/settings/ToolsTab.js
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/components/settings/ToolsTab.js
@@ -31,6 +31,7 @@ import { Plus, Trash2, ChevronDown, ChevronRight, ChevronLeft, RefreshCw, Wrench
 import IOSSwitch from "../ui/IOSSwitch";
 import mcpService, { MCPService } from "../../services/mcpService";
 import ToolForm from "./ToolForm";
+import { darkCssVars, darkModeOverrides, DARK_SURFACE } from "../../config/darkMode";
 import { INTERNAL_TOOL_TABS, INTERNAL_ADDONS } from "../../config/tools-internal";
 
 const NATIVE_TOOLS = [
@@ -801,7 +802,7 @@ export default function ToolsTab() {
   // Check OAuth 2.1 token presence for each oauth2.1 server
   useEffect(() => {
     const checkOauth21Tokens = async () => {
-      const oauth21Servers = servers.filter(s => s.authType === 'oauth2.1');
+      const oauth21Servers = servers.filter(s => s.authType === 'oauth2.1' || s.authType === 'oauth2-user');
       if (oauth21Servers.length === 0) return;
       const updates = {};
       await Promise.all(
@@ -897,12 +898,12 @@ export default function ToolsTab() {
       const toolIds = tools.map(t => `${newServer.id}:${t.name}`);
       setEnabledTools(prev => [...prev, ...toolIds]);
       setToast({ message: `${newServer.name} added · ${tools.length} tools enabled`, severity: 'success' });
-    } else if (newServer.authType === 'oauth2.1') {
+    } else if (newServer.authType === 'oauth2.1' || newServer.authType === 'oauth2-user') {
       // Interactive flow — kick off authorization right away. The user comes back to /settings
       // when done. After return, the server's tools/list will succeed and the chip will load.
       setServerStatus(prev => ({ ...prev, [newServer.id]: null }));
       const returnTo = typeof window !== 'undefined' ? window.location.pathname + window.location.search : '/settings';
-      window.location.href = `/api/mcp/oauth/authorize?endpoint=${encodeURIComponent(newServer.endpoint)}&returnTo=${encodeURIComponent(returnTo)}`;
+      window.location.href = MCPService.buildAuthorizeUrl(newServer, returnTo);
     } else {
       loadServerTools(newServer);
     }
@@ -1199,11 +1200,19 @@ export default function ToolsTab() {
                         }}>
                           {tool.name}
                         </Typography>
-                        <Typography sx={{
-                          fontSize: "0.78rem",
-                          color: "var(--dm-muted, rgba(0,0,0,0.55))",
-                          lineHeight: 1.6,
-                        }}>
+                        <Typography
+                          title={tool.description}
+                          sx={{
+                            fontSize: "0.78rem",
+                            color: "var(--dm-muted, rgba(0,0,0,0.55))",
+                            lineHeight: 1.6,
+                            display: "-webkit-box",
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: "vertical",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                          }}
+                        >
                           {tool.description}
                         </Typography>
                       </Box>
@@ -2114,26 +2123,26 @@ export default function ToolsTab() {
         </Button>
       </Box>
 
-      {/* Add Tool Form — single component handles state, validation, test, OAuth discovery */}
-      {showAddForm && (
-        <Box
-          sx={{
-            border: "1px dashed var(--dm-border, rgba(0,0,0,0.2))",
-            borderRadius: 2,
-            p: 2,
-            mb: 2,
-            mt: 2,
-          }}
-        >
-          <ToolForm
-            mode="add"
-            onSave={handleAddServer}
-            onCancel={() => {
+      {/* Add/Edit Tool dialog — single modal reused by both flows. The state
+          drivers are showAddForm (add) and editingServerId (edit). The mode
+          and initialValues are derived from whichever is set. ToolForm exposes
+          imperative save()/test() via ref so the buttons can live in
+          DialogActions (anchored to the bottom while content scrolls). */}
+      {(showAddForm || editingServerId) && (
+        <ToolDialog
+          mode={editingServerId ? "edit" : "add"}
+          server={editingServerId ? servers.find(s => s.id === editingServerId) : null}
+          serverToolsForEdit={editingServerId ? (serverTools[editingServerId] || []) : []}
+          onSave={editingServerId ? handleSaveEdit : handleAddServer}
+          onClose={() => {
+            if (editingServerId) {
+              handleCancelEdit();
+            } else {
               setShowAddForm(false);
               mcpService.servers.delete('test-new');
-            }}
-          />
-        </Box>
+            }
+          }}
+        />
       )}
 
       {/* Server List */}
@@ -2155,19 +2164,8 @@ export default function ToolsTab() {
               boxShadow: focusedServerId === server.id ? "0 0 0 4px rgba(255, 152, 0, 0.12)" : "none",
             }}
           >
-            {/* Server Header */}
-            {editingServerId === server.id ? (
-              /* Edit Mode — same form as add, prefilled with server values */
-              <Box sx={{ p: 2 }}>
-                <ToolForm
-                  mode="edit"
-                  initialValues={{ ...server, tools: serverTools[server.id] || [] }}
-                  onSave={handleSaveEdit}
-                  onCancel={handleCancelEdit}
-                />
-              </Box>
-            ) : (
-              /* View Mode */
+            {/* Server Header — edit form moved to a shared Dialog above */}
+            {(
               <Box
                 sx={{
                   display: "flex",
@@ -2232,8 +2230,8 @@ export default function ToolsTab() {
                       sx={{ height: 24, backgroundColor: "rgba(198, 40, 40, 0.1)", color: "#c62828", "& .MuiChip-icon": { fontSize: 14, ml: 0.5, color: "#c62828" } }}
                     />
                   )}
-                  {/* OAuth 2.1 authorization status — only shown for oauth2.1 servers */}
-                  {server.authType === 'oauth2.1' && oauth21Status[server.id] === 'needs_auth' && (
+                  {/* User-sign-in authorization status — shown for oauth2.1 (auto-discovery) and oauth2-user (manual setup) */}
+                  {(server.authType === 'oauth2.1' || server.authType === 'oauth2-user') && oauth21Status[server.id] === 'needs_auth' && (
                     <Button
                       size="small"
                       variant="outlined"
@@ -2241,7 +2239,7 @@ export default function ToolsTab() {
                       onClick={(e) => {
                         e.stopPropagation();
                         const returnTo = window.location.pathname + window.location.search;
-                        window.location.href = `/api/mcp/oauth/authorize?endpoint=${encodeURIComponent(server.endpoint)}&returnTo=${encodeURIComponent(returnTo)}`;
+                        window.location.href = MCPService.buildAuthorizeUrl(server, returnTo);
                       }}
                       sx={{
                         height: 26,
@@ -2256,20 +2254,28 @@ export default function ToolsTab() {
                       Authorize
                     </Button>
                   )}
-                  {server.authType === 'oauth2.1' && oauth21Status[server.id] === 'authorized' && (
-                    <Tooltip title="Re-authorize">
-                      <IconButton
-                        size="small"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          const returnTo = window.location.pathname + window.location.search;
-                          window.location.href = `/api/mcp/oauth/authorize?endpoint=${encodeURIComponent(server.endpoint)}&returnTo=${encodeURIComponent(returnTo)}`;
-                        }}
-                        sx={{ color: "rgba(46, 125, 50, 0.7)" }}
-                      >
-                        <KeyRound size={15} />
-                      </IconButton>
-                    </Tooltip>
+                  {(server.authType === 'oauth2.1' || server.authType === 'oauth2-user') && oauth21Status[server.id] === 'authorized' && (
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<KeyRound size={14} />}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        const returnTo = window.location.pathname + window.location.search;
+                        window.location.href = MCPService.buildAuthorizeUrl(server, returnTo);
+                      }}
+                      sx={{
+                        height: 26,
+                        textTransform: "none",
+                        borderColor: "rgba(46, 125, 50, 0.4)",
+                        color: "#2e7d32",
+                        fontSize: "0.72rem",
+                        fontWeight: 500,
+                        "&:hover": { borderColor: "#2e7d32", backgroundColor: "rgba(46, 125, 50, 0.06)" },
+                      }}
+                    >
+                      Re-authorize
+                    </Button>
                   )}
                   {loadingServers[server.id] && (
                     <CircularProgress size={18} />
@@ -2357,7 +2363,19 @@ export default function ToolsTab() {
                           <Typography sx={{ fontWeight: 500, fontSize: "0.9rem" }}>
                             {tool.name}
                           </Typography>
-                          <Typography variant="caption" sx={{ color: "var(--dm-text, rgba(0,0,0,0.6))" }}>
+                          <Typography
+                            variant="caption"
+                            title={tool.description}
+                            sx={{
+                              color: "var(--dm-text, rgba(0,0,0,0.6))",
+                              display: "-webkit-box",
+                              WebkitLineClamp: 2,
+                              WebkitBoxOrient: "vertical",
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              lineHeight: 1.45,
+                            }}
+                          >
                             {tool.description}
                           </Typography>
                         </Box>
@@ -2411,5 +2429,97 @@ export default function ToolsTab() {
         ) : null}
       </Snackbar>
     </motion.div>
+  );
+}
+
+/**
+ * Add/Edit Tool dialog. Encapsulates the local ref + formState plumbing so
+ * the buttons can live in DialogActions (anchored to the bottom while the
+ * form content scrolls naturally inside DialogContent).
+ */
+function ToolDialog({ mode, server, serverToolsForEdit, onSave, onClose }) {
+  const isEdit = mode === "edit";
+  const formRef = useRef(null);
+  const [formState, setFormState] = useState({ isValid: false, isLoading: false, authType: null, testStatus: null, testToolsCount: 0 });
+
+  // The Dialog renders inside a React portal at document.body, so the page-
+  // level dark-mode wrapper does NOT cascade into it. Read the flag locally
+  // and apply darkCssVars + darkModeOverrides directly to the Paper so the
+  // entire dialog subtree is themed correctly.
+  const [isDark, setIsDark] = useState(false);
+  useEffect(() => {
+    try {
+      const ui = JSON.parse(localStorage.getItem("uiSettings") || "{}");
+      setIsDark(ui.darkMode === true);
+    } catch { /* ignore */ }
+  }, []);
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      scroll="paper"
+      PaperProps={{
+        sx: {
+          borderRadius: 2,
+          ...(isDark && {
+            backgroundColor: DARK_SURFACE,
+            ...darkCssVars,
+            ...darkModeOverrides,
+          }),
+        },
+      }}
+    >
+      <DialogTitle sx={{ fontSize: "1rem", fontWeight: 600, pb: 1, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        {isEdit ? "Edit Tool" : "Add MCP Tool"}
+        <IconButton size="small" onClick={onClose} sx={{ ml: 1 }}>
+          <X size={16} />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ pt: "8px !important" }}>
+        <ToolForm
+          ref={formRef}
+          mode={mode}
+          initialValues={isEdit && server ? { ...server, tools: serverToolsForEdit } : null}
+          onSave={onSave}
+          onCancel={onClose}
+          onStateChange={setFormState}
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        {formState.testStatus === "connected" && (
+          <Chip
+            icon={<Plug size={14} />}
+            label={formState.testToolsCount > 0 ? `Connected · ${formState.testToolsCount} tools` : "Connected"}
+            size="small"
+            color="success"
+            variant="outlined"
+            sx={{ mr: 1 }}
+          />
+        )}
+        {formState.authType !== "oauth2.1" && (
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => formRef.current?.test()}
+            disabled={!formState.isValid || formState.isLoading}
+            startIcon={formState.isLoading ? <CircularProgress size={14} /> : <Plug size={14} />}
+          >
+            Test Connection
+          </Button>
+        )}
+        <Button
+          variant="contained"
+          size="small"
+          onClick={() => formRef.current?.save()}
+          disabled={!formState.isValid || formState.isLoading}
+          startIcon={formState.isLoading ? <CircularProgress size={14} /> : <Check size={14} />}
+        >
+          {isEdit ? "Save" : "Add Tool"}
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 }

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/components/ui/Header.js
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/components/ui/Header.js
@@ -242,7 +242,19 @@ export default function Header({
                       style={{ display: "flex", alignItems: "center", gap: 8 }}
                     >
                       <BrainFreezeIcon size={20} color={isDarkBg ? "rgba(255,255,255,0.5)" : "rgba(0, 0, 0, 0.4)"} />
-                      {/* Model name label hidden temporarily — tooltip still shows it on hover */}
+                      <Typography
+                        sx={{
+                          fontSize: "1rem",
+                          color: isDarkBg ? "rgba(255,255,255,0.6)" : "rgba(0, 0, 0, 0.5)",
+                          fontWeight: 400,
+                          maxWidth: 250,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {selectedModel?.replace(/^[a-z]+\./, "") || "Select model"}
+                      </Typography>
                     </motion.div>
                   )}
                 </AnimatePresence>

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/config/version.js
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/config/version.js
@@ -1,3 +1,3 @@
 // Bump on every notable change so the running app's version is visible in Settings.
 // Matches package.json for sanity; either can be the source of truth.
-export const APP_VERSION = "0.4.0";
+export const APP_VERSION = "0.5.0";

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/globals.css
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/globals.css
@@ -4,6 +4,14 @@ body {
   padding: 0;
 }
 
+/* Global font baseline — any element that doesn't set its own font-family
+   inherits Oracle Sans. This is the single source of truth so we don't have
+   to wrap every loose <div>/<Box> text in <Typography> just to get the right
+   font. Code/pre and explicit monospace usages still override locally. */
+body {
+  font-family: var(--font-oracle-sans), sans-serif;
+}
+
 body,
 h1,
 h2,

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/hooks/useChat.js
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/hooks/useChat.js
@@ -351,6 +351,37 @@ export default function useChat({ initialConversationId = null, selectedModel, o
       return [...state.responses];
     }
 
+    // MCP tool the model wants to invoke but OCI did NOT execute itself
+    // (typical with gpt-oss-120b). Show a chip in "calling" state and queue
+    // the call for client-side execution + chained response after the stream
+    // ends. Handled in sendAndStreamMessage's finally block.
+    if (typeof chunk === 'object' && chunk.mcp_function_call) {
+      const fc = chunk.mcp_function_call;
+      state.responses = state.responses.filter(r => r.type !== 'thinking' && r.type !== 'mcp_connecting');
+      const existing = state.responses.find(r => r.type === 'mcp_chip' && r.mcpItemId === fc.item_id);
+      if (!existing) {
+        state.responses.push({
+          type: 'mcp_chip',
+          mcpItemId: fc.item_id,
+          server: fc.server_label,
+          tool: fc.tool_name,
+          arguments: fc.arguments,
+          status: 'calling',
+          label: `Using ${formatToolName(fc.tool_name)}...`,
+        });
+      }
+      state.pendingMcpFunctionCalls = state.pendingMcpFunctionCalls || [];
+      state.pendingMcpFunctionCalls.push({
+        item_id: fc.item_id,
+        call_id: fc.call_id,
+        fn_name: fc.fn_name,
+        server_label: fc.server_label,
+        tool_name: fc.tool_name,
+        arguments: fc.arguments,
+      });
+      return [...state.responses];
+    }
+
     // Handle function call (client-side tool or OCI internal tool)
     if (typeof chunk === 'object' && chunk.function_call) {
       const fcName = chunk.function_call.name;
@@ -672,59 +703,47 @@ export default function useChat({ initialConversationId = null, selectedModel, o
     return [...state.responses];
   }, []);
 
+  // Cleanup after a stream ends. Only acts on REAL errors (user abort, network
+  // failure, explicit stall). For ambiguous endings (e.g. OCI closed without
+  // response.completed) we leave the chips as they are — the UI will render
+  // their natural state. No fabricated error messages.
   const markIncompleteMcpChipsAsFailed = useCallback(() => {
     const state = streamingStateRef.current;
-    const streamCompleted = state?.streamCompleted || false;
     const streamError = state?.streamError;
     const elapsed = state?.streamStartedAt ? Math.round((Date.now() - state.streamStartedAt) / 1000) : null;
 
+    const isRealError = !!streamError && (
+      streamError.name === 'AbortError' ||
+      streamError.name === 'StreamStallError' ||
+      streamError.message?.includes('STREAM_STALL') ||
+      streamError.message?.includes('Failed to fetch') ||
+      streamError.message?.includes('NetworkError')
+    );
+
     updateLatestExchange(exchange => {
-      const sourcesCount = exchange.responses.filter(r => r.type === 'sources').length;
-      if (sourcesCount > 0) console.log('[Sources] Before cleanup:', sourcesCount, 'sources entries in', exchange.responses.length, 'total responses');
       const responses = exchange.responses
-        .filter(r => r.type !== "thinking" && r.type !== "mcp_connecting") // Remove leftover indicators
+        .filter(r => r.type !== "thinking" && r.type !== "mcp_connecting")
         .map(r => {
-          if (r.type === "mcp_chip" && (r.status === "connecting" || r.status === "calling")) {
-            // Build a descriptive error message for debugging
+          // Close any reasoning blocks left mid-stream so the UI stops the
+          // loading dots animation. This is cosmetic only.
+          if (r.type === "reasoning" && r.done === false) return { ...r, done: true };
+
+          // Only mark calling chips as failed on REAL errors (abort/network/stall).
+          // Otherwise leave them — the chain loop or normal flow will update them.
+          if (r.type === "mcp_chip" && (r.status === "connecting" || r.status === "calling") && isRealError) {
             const toolName = formatToolName(r.tool) || r.server || "unknown tool";
             let reason;
-            if (r.error) {
-              reason = r.error;
-            } else if (streamCompleted) {
-              reason = `OCI completed the response while ${toolName} was still running (${elapsed}s). The tool was called but OCI closed the stream before receiving its result. This is a known OCI behavior when an MCP tool call is the model's last action.`;
-            } else if (streamError?.name === 'AbortError') {
-              reason = `Stopped by user while ${toolName} was running (${elapsed}s)`;
-            } else if (streamError?.name === 'StreamStallError' || streamError?.message?.includes('STREAM_STALL')) {
-              reason = `Stream stalled — no data from server for 2+ min while ${toolName} was ${r.status} (${elapsed}s). ${streamError.message}`;
-            } else if (streamError?.name === 'PrematureStreamClose') {
-              reason = `OCI closed connection while ${toolName} was ${r.status} (${elapsed}s). ${streamError.message}`;
-            } else if (streamError?.message?.includes('Failed to fetch') || streamError?.message?.includes('NetworkError')) {
-              reason = `Network error while ${toolName} was ${r.status} (${elapsed}s) — check connection or server`;
-            } else if (streamError) {
-              reason = `${toolName} interrupted after ${elapsed}s: ${streamError.message || String(streamError)}`;
-            } else {
-              reason = `${toolName} was still ${r.status} when stream ended (${elapsed}s) — no error captured, possible silent disconnect`;
-            }
-            console.error(`[MCP] Tool failed: ${toolName}`, { status: r.status, elapsed, streamCompleted, error: streamError?.message });
-            return {
-              ...r,
-              status: "failed",
-              label: formatToolName(r.tool) || r.server || "Failed",
-              error: reason
-            };
+            if (streamError.name === 'AbortError') reason = `Stopped by user while ${toolName} was running (${elapsed}s)`;
+            else if (streamError.name === 'StreamStallError' || streamError.message?.includes('STREAM_STALL'))
+              reason = `Stream stalled while ${toolName} was ${r.status} (${elapsed}s)`;
+            else reason = `Network error while ${toolName} was ${r.status} (${elapsed}s)`;
+            return { ...r, status: "failed", label: formatToolName(r.tool) || r.server || "Failed", error: reason };
           }
-          // Stream ended while a reasoning block was still open — close it so
-          // the UI stops showing the loading dots.
-          if (r.type === "reasoning" && r.done === false) {
-            return { ...r, done: true };
-          }
-          // Code interpreter block still writing/interpreting when stream died.
-          if (r.type === "code_execution" && r.status && r.status !== "completed") {
+          if (r.type === "code_execution" && r.status && r.status !== "completed" && isRealError) {
             return { ...r, status: "failed" };
           }
           return r;
         });
-      // Attach trace to exchange for UI diagnostics
       const requestTrace = streamingStateRef.current?.trace || null;
       return { ...exchange, responses, ...(requestTrace && { trace: requestTrace }) };
     });
@@ -737,32 +756,170 @@ export default function useChat({ initialConversationId = null, selectedModel, o
     const { isNewConversation = false, inputText = "", previousResponseId } = options;
     const sessionActiveServers = inputRef.current?.getSessionActiveServers?.() || undefined;
 
-    try {
-      if (isNewConversation) {
-        await genaiService.createConversation("New conversation");
-        const newConvId = genaiService.getConversationId();
-        if (newConvId) {
-          const storedConv = await ConversationStorage.get(newConvId);
-          if (storedConv?.urlId) {
-            window.history.pushState(null, "", `/c/${storedConv.urlId}`);
-            loadedConversationRef.current = storedConv.urlId;
+    if (isNewConversation) {
+      await genaiService.createConversation("New conversation");
+      const newConvId = genaiService.getConversationId();
+      if (newConvId) {
+        const storedConv = await ConversationStorage.get(newConvId);
+        if (storedConv?.urlId) {
+          window.history.pushState(null, "", `/c/${storedConv.urlId}`);
+          loadedConversationRef.current = storedConv.urlId;
+        }
+      }
+    }
+
+    let result = null;
+    let primaryError = null;
+
+      // Initial send — capture its error (if any) but DON'T let it short-circuit
+      // the client-side MCP execution loop below. Some failures (e.g. OCI closing
+      // the stream after a function_call) leave pendingMcpFunctionCalls populated
+      // and we still want to execute the tool + chain a follow-up.
+      try {
+        result = await genaiService.sendMessage(
+          input,
+          (chunk) => {
+            const responsesCopy = processStreamingChunk(chunk, streamingStateRef.current);
+            updateLatestExchange(exchange => ({ ...exchange, responses: responsesCopy }));
+          },
+          { model: selectedModel || undefined, sessionActiveServers, previousResponseId }
+        );
+      } catch (err) {
+        primaryError = err;
+        if (streamingStateRef.current) streamingStateRef.current.streamError = err;
+      }
+
+      // Client-side MCP execution loop. Some models (gpt-oss-120b) emit MCP
+      // tool calls as OpenAI-style function_call and expect the client to
+      // execute them and submit a function_call_output back via a chained
+      // Responses request. Runs regardless of whether the initial stream errored.
+      let chainDepth = 0;
+      let needsAuthFor = null; // { name, endpoint, authType } when an MCP server needs OAuth
+      while ((streamingStateRef.current.pendingMcpFunctionCalls || []).length > 0 && chainDepth < 5) {
+        chainDepth++;
+        const pending = streamingStateRef.current.pendingMcpFunctionCalls;
+        streamingStateRef.current.pendingMcpFunctionCalls = [];
+
+        const chainInput = [];
+        for (const fc of pending) {
+          const server = (typeof window !== 'undefined' ? JSON.parse(localStorage.getItem('mcpServers') || '[]') : [])
+            .find(s => {
+              let label = (s.name || '').replace(/[^a-zA-Z0-9_-]/g, '_');
+              if (!/^[a-zA-Z]/.test(label)) label = 'mcp_' + label;
+              return label === fc.server_label;
+            });
+          let parsedArgs;
+          try { parsedArgs = JSON.parse(fc.arguments || '{}'); } catch { parsedArgs = {}; }
+
+          let output;
+          let authRequired = false;
+          if (!server) {
+            output = JSON.stringify({ error: `Server '${fc.server_label}' not configured` });
+          } else {
+            try {
+              const res = await fetch('/api/mcp', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  endpoint: server.endpoint,
+                  method: 'tools/call',
+                  params: { name: fc.tool_name, arguments: parsedArgs },
+                  authType: server.authType,
+                  authKey: server.authKey,
+                  oauth: server.oauth,
+                }),
+              });
+              const data = await res.json();
+              if (res.status === 401 && data.error === 'needs_auth') {
+                // OAuth token missing/expired — abort the chain and surface a
+                // banner inviting the user to authorize. The model NEVER sees
+                // the auth failure, so it doesn't try to summarise it.
+                authRequired = true;
+                needsAuthFor = { name: server.name, endpoint: server.endpoint, authType: server.authType };
+              } else if (data.result?.content) {
+                output = data.result.content.map(c => c.text || JSON.stringify(c)).join('\n');
+              } else if (data.error) {
+                output = JSON.stringify({ error: data.error.message || JSON.stringify(data.error) });
+              } else {
+                output = JSON.stringify(data);
+              }
+            } catch (err) {
+              output = JSON.stringify({ error: err.message || String(err) });
+            }
           }
+
+          // Update the chip in BOTH the React exchange AND the streaming state.
+          // The chained sendMessage will replace exchange.responses with
+          // state.responses on every chunk, so updating just exchange would be
+          // overwritten the moment the chained stream starts. We mutate
+          // state.responses in place so subsequent chunks preserve the update.
+          const applyChipUpdate = (chip) => {
+            if (chip.type !== 'mcp_chip') return chip;
+            // Match by mcpItemId first; fall back to tool+server for the case
+            // where output_item.added(mcp_call) never fired (rare).
+            const matches = chip.mcpItemId === fc.item_id
+              || (fc.item_id == null && chip.tool === fc.tool_name && chip.server === fc.server_label && (chip.status === 'calling' || chip.status === 'connecting'));
+            if (!matches) return chip;
+            if (authRequired) {
+              return { ...chip, status: 'failed', label: formatToolName(fc.tool_name) || 'Authorization required', error: 'Authorization required' };
+            }
+            return { ...chip, status: 'completed', output, label: formatToolName(fc.tool_name) || 'Completed' };
+          };
+          if (streamingStateRef.current?.responses) {
+            streamingStateRef.current.responses = streamingStateRef.current.responses.map(applyChipUpdate);
+          }
+          updateLatestExchange(exchange => ({
+            ...exchange,
+            responses: (exchange.responses || []).map(applyChipUpdate),
+          }));
+
+          if (!authRequired) {
+            chainInput.push(
+              { type: 'function_call', name: fc.fn_name, arguments: fc.arguments, call_id: fc.call_id },
+              { type: 'function_call_output', call_id: fc.call_id, output },
+            );
+          }
+        }
+
+        if (needsAuthFor) break; // skip chained call, surface banner instead
+
+        try {
+          result = await genaiService.sendMessage(
+            chainInput,
+            (chunk) => {
+              const responsesCopy = processStreamingChunk(chunk, streamingStateRef.current);
+              updateLatestExchange(exchange => ({ ...exchange, responses: responsesCopy }));
+            },
+            { model: selectedModel || undefined, sessionActiveServers },
+          );
+          // If the chained request succeeds we no longer need to surface the
+          // original error (the tool ran, the model summarised, the user is fine).
+          primaryError = null;
+        } catch (err) {
+          if (streamingStateRef.current) streamingStateRef.current.streamError = err;
+          primaryError = err;
+          break;
         }
       }
 
-      const result = await genaiService.sendMessage(
-        input,
-        (chunk) => {
-          const responsesCopy = processStreamingChunk(chunk, streamingStateRef.current);
-          updateLatestExchange(exchange => ({
-            ...exchange,
-            responses: responsesCopy,
-          }));
-        },
-        { model: selectedModel || undefined, sessionActiveServers, previousResponseId }
-      );
+      // Auth required somewhere along the chain — push the existing
+      // mcp_auth_expired banner so the user can re-authorize from the chat.
+      if (needsAuthFor) {
+        updateLatestExchange(exchange => ({
+          ...exchange,
+          responses: [...(exchange.responses || []), {
+            type: 'error',
+            content: 'mcp_auth_expired',
+            serverLabel: needsAuthFor.name || null,
+            serverEndpoint: needsAuthFor.endpoint || null,
+            serverAuthType: needsAuthFor.authType || null,
+          }],
+        }));
+        // Don't surface a generic error on top of the banner.
+        primaryError = null;
+      }
 
-      // Persist the raw accumulated text and trace for export/diagnostics
+      // Persist accumulated text + trace
       const rawText = streamingStateRef.current.accumulatedText || '';
       const requestTrace = streamingStateRef.current.trace || null;
       if (rawText || requestTrace) {
@@ -773,8 +930,8 @@ export default function useChat({ initialConversationId = null, selectedModel, o
         }));
       }
 
-      // Generate title for new conversations or conversations that were stopped before getting a title
-      if (result.answer && inputText) {
+      // Generate title for new conversations
+      if (result?.answer && inputText) {
         const convId = genaiService.getConversationId();
         if (convId) {
           const needsTitle = isNewConversation || await ConversationStorage.get(convId).then(c => !c?.title || c.title === "New conversation").catch(() => false);
@@ -788,42 +945,38 @@ export default function useChat({ initialConversationId = null, selectedModel, o
         }
       }
 
+      if (primaryError) {
+        if (primaryError.name === 'AbortError') {
+          return { answer: streamingStateRef.current?.accumulatedText || '', stopped: true };
+        }
+        console.error('Error calling agent:', primaryError);
+        if (primaryError.type === 'mcp_auth_expired') {
+          updateLatestExchange(exchange => ({
+            ...exchange,
+            responses: [...(exchange.responses || []), {
+              type: 'error',
+              content: 'mcp_auth_expired',
+              serverLabel: primaryError.serverLabel || null,
+              serverEndpoint: primaryError.serverEndpoint || null,
+              serverAuthType: primaryError.serverAuthType || null,
+            }],
+          }));
+        } else {
+          updateLatestExchange(exchange => ({
+            ...exchange,
+            responses: [...(exchange.responses || []), {
+              type: 'error',
+              content: primaryError.message || String(primaryError),
+              opcRequestId: primaryError.opcRequestId || null,
+              model: primaryError.model || null,
+              timestamp: primaryError.timestamp || null,
+            }],
+          }));
+        }
+        throw primaryError;
+      }
+
       return result;
-    } catch (error) {
-      // Capture error for markIncompleteMcpChipsAsFailed
-      if (streamingStateRef.current) {
-        streamingStateRef.current.streamError = error;
-      }
-      if (error.name === 'AbortError') {
-        // User stopped generation — keep partial content, don't show error
-        return { answer: streamingStateRef.current?.accumulatedText || '', stopped: true };
-      }
-      console.error("Error calling agent:", error);
-      if (error.type === 'mcp_auth_expired') {
-        updateLatestExchange(exchange => ({
-          ...exchange,
-          responses: [...(exchange.responses || []), {
-            type: "error",
-            content: "mcp_auth_expired",
-            serverLabel: error.serverLabel || null,
-            serverEndpoint: error.serverEndpoint || null,
-            serverAuthType: error.serverAuthType || null,
-          }],
-        }));
-      } else {
-        updateLatestExchange(exchange => ({
-          ...exchange,
-          responses: [...(exchange.responses || []), {
-            type: "error",
-            content: error?.message || String(error),
-            opcRequestId: error?.opcRequestId || null,
-            model: error?.model || null,
-            timestamp: error?.timestamp || null,
-          }],
-        }));
-      }
-      throw error;
-    }
   }, [genaiService, selectedModel, processStreamingChunk, updateLatestExchange, refreshRecentConversations]);
 
   useEffect(() => {

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/services/genaiAgentsService.js
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/services/genaiAgentsService.js
@@ -400,12 +400,17 @@ const createGenaiAgentService = () => {
           // the "PrematureStreamClose" thrown in the finally block and the user
           // sees a misleading "OCI dropped the connection" message.
           if (data.done) {
+            // Always flag serverDone so the finally block doesn't double-report
+            // a PrematureStreamClose. But ONLY forward done:true to the chunk
+            // handler when there is NO error: marking the stream as completed
+            // when it actually failed makes markIncompleteMcpChipsAsFailed pick
+            // the wrong reason ("OCI completed while X was running") instead of
+            // the real interruption message.
             serverDone = true;
-            if (onChunk) onChunk({ done: true, trace: data.trace || null });
+            if (!data.error && onChunk) onChunk({ done: true, trace: data.trace || null });
           }
 
           if (data.error) {
-            // Forward trace even on error so UI can show diagnostics
             if (data.trace && onChunk) onChunk({ trace: data.trace });
             throw new Error(data.error);
           }
@@ -484,6 +489,14 @@ const createGenaiAgentService = () => {
             onChunk({ mcp_approval_request: data.mcp_approval_request });
           }
 
+          // Forward MCP function call (client-side execution path). For models
+          // that emit MCP tool calls as OpenAI-style function_call (gpt-oss-120b
+          // et al.), useChat will execute the tool itself and chain a follow-up
+          // request with function_call_output.
+          if (data.mcp_function_call && onChunk) {
+            onChunk({ mcp_function_call: data.mcp_function_call });
+          }
+
           // Track response ID for potential chaining
           if (data.response_id) {
             lastResponseId = data.response_id;
@@ -491,7 +504,7 @@ const createGenaiAgentService = () => {
           }
 
           // Log unhandled chunk types for debugging
-          if (!data.text && !data.mcp && !data.thinking && !data.annotations && !data.generated_image && !data.reasoning && !data.code_execution && !data.code_delta && !data.code_status && !data.item_error && !data.function_call && !data.mcp_approval_request && !data.done && !data.text_done && !data.conversation_id && !data.response_id && !data.error && !data.response_incomplete) {
+          if (!data.text && !data.mcp && !data.thinking && !data.annotations && !data.generated_image && !data.reasoning && !data.code_execution && !data.code_delta && !data.code_status && !data.item_error && !data.function_call && !data.mcp_approval_request && !data.mcp_function_call && !data.done && !data.text_done && !data.conversation_id && !data.response_id && !data.error && !data.response_incomplete && !data.no_summary) {
             console.warn('[Stream] Unhandled chunk type:', Object.keys(data), data);
           }
         }

--- a/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/services/mcpService.js
+++ b/ai/gen-ai-agents/oci-enterprise-ai-chat/files/src/app/services/mcpService.js
@@ -258,6 +258,30 @@ ${toolDescriptions}
   }
 
   /**
+   * Build the `/api/mcp/oauth/authorize` URL for a given server, including the
+   * static OAuth params when the server uses `oauth2-user` (no dynamic
+   * registration). For `oauth2.1` only the endpoint is needed — the backend
+   * discovers everything from the MCP server's metadata.
+   *
+   * @param {MCPServer} server
+   * @param {string} returnTo Where to send the user once the flow completes
+   * @returns {string} Full URL ready for `window.location.href = ...`
+   */
+  static buildAuthorizeUrl(server, returnTo) {
+    const qs = new URLSearchParams();
+    qs.set('endpoint', server.endpoint);
+    qs.set('returnTo', returnTo);
+    if (server.authType === 'oauth2-user' && server.oauth) {
+      if (server.oauth.clientId)     qs.set('clientId',     server.oauth.clientId);
+      if (server.oauth.clientSecret) qs.set('clientSecret', server.oauth.clientSecret);
+      if (server.oauth.authorizeUrl) qs.set('authorizeUrl', server.oauth.authorizeUrl);
+      if (server.oauth.tokenUrl)     qs.set('tokenUrl',     server.oauth.tokenUrl);
+      if (server.oauth.scope)        qs.set('scope',        server.oauth.scope);
+    }
+    return `/api/mcp/oauth/authorize?${qs.toString()}`;
+  }
+
+  /**
    * Add a new MCP server
    * @param {Omit<MCPServer, 'id'>} server
    * @returns {MCPServer}


### PR DESCRIPTION
## Summary

Syncs the `ai/gen-ai-agents/oci-enterprise-ai-chat/files/` asset from upstream development (v0.4.0 → v0.5.0).

### Highlights

- **MCP — static-client OAuth (`oauth2-user`)**: new auth type with one-click presets for Google, GitHub, Slack and Microsoft. Lets users connect MCP servers behind OAuth providers that don't support RFC 7591 dynamic client registration. User pre-creates the OAuth client in the provider's console, pastes `client_id` / `client_secret` + the authorize/token URLs, and the app runs PKCE against them.
- **MCP — client-side function_call execution**: some models (`gpt-oss-120b` et al.) emit MCP tool invocations as plain OpenAI-style `function_call` events rather than running them server-side. The client now detects `mcp__<server>__<tool>` names, executes the tool against the configured MCP server, and chains a follow-up Responses request with `function_call_output` so the model can finish.
- **Stream handling cleanup**: stops fabricating "PrematureStreamClose" errors when OCI ends the SSE without `response.completed` after a delegated function_call — that's normal flow, and the old error message confused users. Chips are now only marked failed on real abort / network / stall errors.
- **Style**: Oracle Sans as the global font baseline on `body`, so any loose `<div>`/`<Box>` inherits it without needing a `<Typography>` wrapper.
- **Header**: restored the model name label next to the icon.
- **Chore**: package rename to `oci-enterprise-ai-chat`, version bump `0.4.0` → `0.5.0`, removed SDD Generator add-on from chat input + OAuth helper text.

### Files touched

14 files, +797 / -257 — all under `ai/gen-ai-agents/oci-enterprise-ai-chat/files/`. No changes outside that asset.

## Test plan

- [x] `npm run dev` — app boots, no console errors
- [x] OAuth `oauth2.1` flow (existing) still works against an MCP server with dynamic registration
- [x] OAuth `oauth2-user` flow — connect Google Gmail with preset, complete consent, tool call returns data
- [x] gpt-oss-120b — MCP tool invoked, runs client-side, model receives output and finishes
- [x] Oracle Sans applied across components