### PR TITLE
Remove backup blog link from README

### DIFF
--- a/data-platform/autonomous-ai-database/autonomous-database-dedicated/README.md
+++ b/data-platform/autonomous-ai-database/autonomous-database-dedicated/README.md
@@ -44,8 +44,6 @@ Reviewed: 28.10.2025
 - [Oracle Autonomous Database Dedicated for Security Administrators](https://apexapps.oracle.com/pls/apex/r/dbpm/livelabs/view-workshop?wid=3198&clear=RR,180)
     - This set of hands-on labs is designed to assist database security administrators with setting up and using various features of the Autonomous Database on the dedicated Exadata Infrastructure service.
  
- - [Streamline Backups for Oracle Autonomous AI Database on Exadata Cloud@Customer with ZDLRA as the Destination](https://blogs.oracle.com/autonomous-ai-database/streamline-backups-for-oracle-autonomous-ai-database-on-exadata-cloudcustomer-with-zdlra-as-the-destination)
-    - The blog is a step-by-step guide on how to enable and configure the backup destination to ZDLRA at ACD level in an ADB C@C scenario.
     
 # License
  


### PR DESCRIPTION
Removed a blog link related to backups for Oracle Autonomous AI Database.